### PR TITLE
Add the assemble step

### DIFF
--- a/assemble/assemble.ml
+++ b/assemble/assemble.ml
@@ -216,8 +216,11 @@ let assemble_package_pages ~blessed_packages ~deps ~root universes =
       let src = package_root ~root uni pkg ver in
       Util.mv src ~dst;
       Deps.rename deps src ~dst;
-      let pkg_page = index_page_of_dir dst in
-      write_file pkg_page (gen_package_page pkg.p_name ver) )
+      write_file (index_page_of_dir dst) (gen_package_page pkg.p_name ver);
+      (* Update deps so the universe package page can still reference this. *)
+      Deps.add deps
+        (versions_list_page ~root uni pkg)
+        [ blessed_versions_list_root ~root pkg ] )
     else
       write_file
         (index_page_of_dir (package_root ~root uni pkg ver))

--- a/assemble/assemble.ml
+++ b/assemble/assemble.ml
@@ -1,0 +1,262 @@
+(** Prepare a "prep" tree for odocmkgen:
+    - Add listing packages (universes, packages in universes, versions of packages)
+    - Add default package page if there is not already one
+    - TODO: Add some informations to user's package pages ?
+      (dependencies to other packages, list of modules and pages)
+    *)
+
+open Builder
+
+let ( / ) = Fpath.( / )
+
+let fpf = Printf.fprintf
+
+(* TODO: Take this as CLI argument. *)
+let top_path = Fpath.v "prep"
+
+module Deps : sig
+  type t
+  (** Mutable data-structure storing dependencies. *)
+
+  val create : unit -> t
+
+  val add : t -> target:Fpath.t -> Fpath.t list -> unit
+  (** Paths are internally normalized. [target] must be a path to a file, deps
+      can be paths to files or directories. *)
+
+  val fold : (Fpath.t -> Fpath.t list -> 'a -> 'a) -> t -> 'a -> 'a
+end = struct
+  module Tbl = Hashtbl.Make (struct
+    type t = Fpath.t
+
+    let equal = Fpath.equal
+
+    let hash = Hashtbl.hash
+  end)
+
+  type t = Fpath.t list Tbl.t
+
+  let create () = Tbl.create 50
+
+  let add tbl ~target extra_deps =
+    let target = Fpath.normalize target in
+    let deps = match Tbl.find_opt tbl target with Some d -> d | None -> [] in
+    let extra_deps = List.rev_map Fpath.normalize extra_deps in
+    Tbl.replace tbl target (List.rev_append extra_deps deps)
+
+  let fold = Tbl.fold
+end
+
+let write_file p f =
+  let out = open_out (Fpath.to_string p) in
+  Format.eprintf "Create '%a'\n" Fpath.pp p;
+  Fun.protect ~finally:(fun () -> close_out out) (fun () -> f out)
+
+let index_page_of_dir d =
+  let parent, base = Fpath.split_base d in
+  Fpath.( // ) parent (Fpath.set_ext ".mld" base)
+
+let is_dir (_, p) = Sys.is_directory (Fpath.to_string p)
+
+let is_hidden s =
+  let len = String.length s in
+  let rec aux i =
+    if i > len - 2 then false
+    else if s.[i] = '_' && s.[i + 1] = '_' then true
+    else aux (i + 1)
+  in
+  aux 0
+
+(** Replace '-' by '_' and add the "page-" prefix. That's what [odocmkgen] is
+    doing. *)
+let page_name_of_string n =
+  "page-" ^ String.concat "_" (String.split_on_char '-' n)
+
+let module_name_of_string = String.capitalize_ascii
+
+(** This is an approximation. *)
+let module_name_of_path f =
+  if Fpath.mem_ext [ ".cmti"; ".cmt"; ".cmi" ] f then
+    Some (module_name_of_string (Fpath.basename (Fpath.rem_ext f)))
+  else None
+
+type subpkg = { s_relpath : Fpath.t; s_modules : string list }
+
+type version = { v_name : string; v_subpkgs : subpkg list }
+
+type package = { p_name : string; p_versions : version list }
+
+type universe = { u_name : string; u_packages : package list }
+
+(** Search recursively for sub-packages, a directory = a sub package.
+    TODO: this is not working in most cases. *)
+let rec read_subpkgs prefix p =
+  let get_module (_, p) =
+    match module_name_of_path p with
+    | Some m as m' when not (is_hidden m) -> m'
+    | _ -> None
+  in
+  let dirs, files = List.partition is_dir (Util.list_dir p) in
+  let s_modules =
+    List.sort_uniq String.compare (List.filter_map get_module files)
+  in
+  { s_relpath = prefix; s_modules }
+  :: List.concat_map (fun (s, p') -> read_subpkgs (prefix / s) p') dirs
+
+let read_versions p =
+  Util.list_dir p |> List.filter is_dir
+  |> List.map (fun (v_name, p') ->
+         { v_name; v_subpkgs = read_subpkgs (Fpath.v "lib") (p' / "lib") })
+
+let read_packages p =
+  Util.list_dir p |> List.filter is_dir
+  |> List.map (fun (p_name, p') -> { p_name; p_versions = read_versions p' })
+
+let read_universes p =
+  Util.list_dir p |> List.filter is_dir
+  |> List.map (fun (u_name, p') -> { u_name; u_packages = read_packages p' })
+
+let pp_childpages out =
+  List.iter (fun p -> fpf out "- {!childpage:%s}\n" (page_name_of_string p))
+
+let pp_childmodules out = List.iter (fpf out "- {!childmodule:%s}\n")
+
+let gen_universes_list universes out =
+  fpf out
+    "{0 Universes}\n\
+     These universes are for those packages that are compiled against an \
+     alternative set of dependencies than those in the 'packages' hierarchy.\n";
+  pp_childpages out (List.map (fun u -> u.u_name) universes);
+  ()
+
+let gen_universe_page universe out =
+  fpf out
+    "{0 Universe %s}\n\
+     {1 Packages}\n\
+     This dependency universe has been used to compile the following packages:\n"
+    universe.u_name;
+  pp_childpages out (List.map (fun p -> p.p_name) universe.u_packages);
+  ()
+
+let gen_versions_list pkg out =
+  fpf out "{0 Package '%s'}\n{1 Versions}\n" pkg.p_name;
+  pp_childpages out (List.map (fun v -> v.v_name) pkg.p_versions);
+  ()
+
+let gen_package_page pkg_name ver out =
+  let gen_subpkg subpkg =
+    let segs = match Fpath.segs subpkg.s_relpath with _ :: tl | tl -> tl in
+    let name = String.concat "." (pkg_name :: segs) in
+    fpf out "{1 [%s]}\n" name;
+    pp_childmodules out subpkg.s_modules;
+    ()
+  in
+  fpf out "{0 Package '%s' version %s}\n" pkg_name ver.v_name;
+  List.iter gen_subpkg ver.v_subpkgs;
+  ()
+
+let assemble_package p pkg_name ver =
+  let p = p / ver.v_name in
+  write_file (index_page_of_dir p) (gen_package_page pkg_name ver)
+
+let assemble_package_versions p pkg =
+  let p = p / pkg.p_name in
+  write_file (index_page_of_dir p) (gen_versions_list pkg);
+  List.iter (assemble_package p pkg.p_name) pkg.p_versions
+
+let assemble_universe p universe =
+  let p = p / universe.u_name in
+  write_file (index_page_of_dir p) (gen_universe_page universe);
+  List.iter (assemble_package_versions p) universe.u_packages
+
+let assemble_universes p universes =
+  write_file (index_page_of_dir p) (gen_universes_list universes);
+  List.iter (assemble_universe p) universes
+
+let query_comple_deps p =
+  let process_line line =
+    match Astring.String.cuts ~sep:" " line with
+    | [ c_name; c_digest ] -> Some (c_name, c_digest)
+    | _ -> None
+  in
+  Util.lines_of_process "odoc" [ "compile-deps"; Fpath.to_string p ]
+  |> List.filter_map process_line
+
+let rec list_dir_rec acc p =
+  Util.list_dir p
+  |> List.fold_left
+       (fun acc ((_, f) as f') ->
+         if is_dir f' then list_dir_rec acc f else f :: acc)
+       acc
+
+module DigestMap = Map.Make (Digest)
+
+let compute_compile_deps paths =
+  let deps_and_digest f =
+    (* Query [odoc compile-deps]. *)
+    if not (Fpath.mem_ext [ ".cmti"; ".cmt"; ".cmi" ] f) then None
+    else
+      let unit_name =
+        String.capitalize_ascii Fpath.(to_string (rem_ext (base f)))
+      in
+      match
+        List.partition (fun (name, _) -> name = unit_name) (query_comple_deps f)
+      with
+      | [ self ], deps -> Some (snd self, List.map snd deps)
+      | _ ->
+          Format.eprintf "Failed to find digest for self (%a)\n%!" Fpath.pp f;
+          None
+  in
+  let deps_and_digests = List.rev_map deps_and_digest paths in
+  let inputs_by_digest =
+    List.fold_left2
+      (fun acc f -> function Some (digest, _) -> DigestMap.add digest f acc
+        | None -> acc)
+      DigestMap.empty paths deps_and_digests
+  in
+  let find_dep dep = DigestMap.find_opt dep inputs_by_digest in
+  let deps_tbl = Deps.create () in
+  List.iter2
+    (fun target -> function
+      | Some (_, deps) ->
+          Deps.add deps_tbl ~target (List.filter_map find_dep deps)
+      | None -> ())
+    paths deps_and_digests;
+  deps_tbl
+
+(** Temporary: Will be done by [prep] when collecting object files. Collect deps
+    for every object files. *)
+let assemble_dep_file deps dst =
+  let print_relpath p =
+    (* Make sure the paths are relative to [top_path]. *)
+    match Fpath.relativize ~root:top_path p with
+    | Some r -> Fpath.to_string r
+    | None -> assert false
+  in
+  write_file dst (fun out ->
+      Deps.fold
+        (fun target deps () ->
+          if deps = [] then ()
+          else (
+            fpf out "%s" (print_relpath target);
+            List.iter (fun p -> fpf out " %s" (print_relpath p)) deps;
+            fpf out "\n" ))
+        deps ())
+
+let run () =
+  let deps = list_dir_rec [] top_path |> compute_compile_deps in
+  let universes = read_universes (top_path / "universes") in
+  assemble_universes (top_path / "universes") universes;
+  assemble_dep_file deps (top_path / "dep")
+
+open Cmdliner
+
+let cmd = Term.(const run $ const ())
+
+let info =
+  Term.info "assemble"
+    ~doc:
+      "Add package and listing pages to a prepared directory tree. Must be \
+       called after $(b,prep) and before $(b,odocmkgen)."
+
+let () = Term.exit (Term.eval (cmd, info))

--- a/assemble/assemble.ml
+++ b/assemble/assemble.ml
@@ -117,7 +117,10 @@ let gen_package_page pkg_name ver out =
 
 let gen_blessed_package_list pkgs out =
   fpf out "{0 Packages}\n";
-  pp_childpages out (List.map (fun p -> p.p_name) pkgs)
+  group_by ~cmp:Char.compare (fun p -> Char.uppercase_ascii p.p_name.[0]) pkgs
+  |> List.iter (fun (c, pkg_group) ->
+         fpf out "{1 %c}" c;
+         pp_childpages out (List.map (fun p -> p.p_name) pkg_group))
 
 let gen_blessed_version_list = gen_version_list
 

--- a/assemble/compile_deps.ml
+++ b/assemble/compile_deps.ml
@@ -1,0 +1,46 @@
+open Builder
+open Util
+
+let query p =
+  let process_line line =
+    match Astring.String.cuts ~sep:" " line with
+    | [ c_name; c_digest ] -> Some (c_name, c_digest)
+    | _ -> None
+  in
+  Util.lines_of_process "odoc" [ "compile-deps"; Fpath.to_string p ]
+  |> List.filter_map process_line
+
+module DigestMap = Map.Make (Digest)
+
+let compute paths =
+  let deps_and_digest f =
+    (* Query [odoc compile-deps]. *)
+    if not (Fpath.mem_ext [ ".cmti"; ".cmt"; ".cmi" ] f) then None
+    else
+      let unit_name =
+        String.capitalize_ascii Fpath.(to_string (rem_ext (base f)))
+      in
+      match List.partition (fun (name, _) -> name = unit_name) (query f) with
+      | [ self ], deps -> Some (snd self, List.map snd deps)
+      | _ ->
+          Format.eprintf "Failed to find digest for self (%a)\n%!" Fpath.pp f;
+          None
+  in
+  let deps_and_digests = List.rev_map deps_and_digest paths in
+  let inputs_by_digest =
+    List.fold_left2
+      (fun acc f -> function Some (digest, _) -> DigestMap.add digest f acc
+        | None -> acc)
+      DigestMap.empty paths deps_and_digests
+  in
+  let find_dep dep = DigestMap.find_opt dep inputs_by_digest in
+  let deps_tbl = Deps.create () in
+  List.iter2
+    (fun target -> function
+      | Some (_, deps) ->
+          Deps.add deps_tbl target (List.filter_map find_dep deps) | None -> ())
+    paths deps_and_digests;
+  deps_tbl
+
+(** Scan a directory and compute the dependencies of every object files. *)
+let of_dir_rec root = list_dir_rec root |> compute

--- a/assemble/compile_deps.ml
+++ b/assemble/compile_deps.ml
@@ -26,7 +26,7 @@ let compute paths =
           Format.eprintf "Failed to find digest for self (%a)\n%!" Fpath.pp f;
           None
   in
-  let deps_and_digests = List.rev_map deps_and_digest paths in
+  let deps_and_digests = List.map deps_and_digest paths in
   let inputs_by_digest =
     List.fold_left2
       (fun acc f -> function Some (digest, _) -> DigestMap.add digest f acc

--- a/assemble/dune
+++ b/assemble/dune
@@ -1,0 +1,3 @@
+(executable
+ (public_name assemble)
+ (libraries cmdliner builder))

--- a/assemble/dune
+++ b/assemble/dune
@@ -1,3 +1,5 @@
 (executable
  (public_name assemble)
- (libraries cmdliner builder))
+ (libraries cmdliner builder fpath)
+ (preprocess
+  (pps ppx_deriving.ord)))

--- a/lib/deps.ml
+++ b/lib/deps.ml
@@ -1,0 +1,63 @@
+module M = Fpath.Map
+
+(** Internal normalization, also remove trailing separator. *)
+let norm p = Fpath.(rem_empty_seg (normalize p))
+
+module Target : sig
+  type target = private { mutable path : Fpath.t; mutable deps : target list }
+
+  val add : target M.t ref -> Fpath.t -> target list -> target
+  (** Add a new target or update an existing one. *)
+
+  val rename : target M.t ref -> target -> dst:Fpath.t -> unit
+  (** [dst] must not exist in the map. *)
+end = struct
+  type target = { mutable path : Fpath.t; mutable deps : target list }
+  (** Mutable to support renaming. *)
+
+  (** This is the only function that can create a [target]. *)
+  let add tbl path deps =
+    let path = norm path in
+    match M.find_opt path !tbl with
+    | Some t ->
+        t.deps <- deps @ t.deps;
+        t
+    | None ->
+        let t = { path; deps } in
+        tbl := M.add path t !tbl;
+        t
+
+  let rename tbl target ~dst =
+    let dst = norm dst in
+    if M.mem dst !tbl then failwith "Deps.rename: Collision";
+    let old_target = target.path in
+    target.path <- dst;
+    tbl := M.add dst target (M.remove old_target !tbl)
+end
+
+type t = Target.target M.t ref
+
+let create () = ref M.empty
+
+let add tbl path deps =
+  let deps = List.rev_map (fun dep -> Target.add tbl dep []) deps in
+  ignore (Target.add tbl path deps)
+
+let rename tbl src ~dst =
+  let src = norm src in
+  let rec rename_loop = function
+    | Seq.Nil -> ()
+    | Cons ((_, target), tl) -> (
+        match Fpath.rem_prefix src target.Target.path with
+        | None -> ()
+        | Some suffix ->
+            Target.rename tbl target ~dst:(Fpath.( // ) dst suffix);
+            rename_loop (tl ()) )
+  in
+  rename_loop (M.to_seq_from src !tbl ())
+
+let fold f tbl acc =
+  M.fold
+    (fun _ { Target.path; deps } acc ->
+      f path (List.rev_map (fun t -> t.Target.path) deps) acc)
+    !tbl acc

--- a/lib/deps.mli
+++ b/lib/deps.mli
@@ -1,0 +1,14 @@
+type t
+(** Mutable data-structure storing dependencies. The main feature is {!rename}. *)
+
+val create : unit -> t
+
+val add : t -> Fpath.t -> Fpath.t list -> unit
+(** Incrementally add dependencies [deps] to [target]. Paths are internally
+    normalized. *)
+
+val rename : t -> Fpath.t -> dst:Fpath.t -> unit
+(** Rename a record and every records for which [src] is a prefix. Paths are
+    internally normalized. *)
+
+val fold : (Fpath.t -> Fpath.t list -> 'a -> 'a) -> t -> 'a -> 'a

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -40,3 +40,10 @@ let time txt fn a =
 let cp src dst =
   Format.eprintf "%s -> %s\n%!" src dst;
   assert (lines_of_process "cp" [ src; dst ] = [])
+
+let list_dir p =
+  match Sys.readdir (Fpath.to_string p) with
+  | exception Sys_error _ -> []
+  | names ->
+      Array.sort String.compare names;
+      Array.map (fun n -> (n, Fpath.( / ) p n)) names |> Array.to_list

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -47,3 +47,17 @@ let list_dir p =
   | names ->
       Array.sort String.compare names;
       Array.map (fun n -> (n, Fpath.( / ) p n)) names |> Array.to_list
+
+let mv src ~dst =
+  let src = Fpath.to_string src and dst = Fpath.to_string dst in
+  Sys.rename src dst
+
+let group_by (type a) ~(cmp : a -> a -> int) (key : 'b -> a) lst =
+  let module M = Map.Make (struct
+    type t = a
+
+    let compare = cmp
+  end) in
+  let to_lst = function Some v -> v | None -> [] in
+  let multi_add acc b = M.update (key b) (fun v -> Some (b :: to_lst v)) acc in
+  List.fold_left multi_add M.empty lst |> M.bindings


### PR DESCRIPTION
This step run on the output of 'prep' and generates listing and package pages.
It adds listing pages (universes, packages, versions of packages) and package pages.

This should implement most of https://github.com/jonludlam/odocmkgen/tree/docs-ocaml-org and works with [this branch of odocmkgen](https://github.com/Julow/odocmkgen/tree/work-with-voodoo) on the tree generated by [the old voodoo-prep](https://github.com/jonludlam/voodoo-prep)

It also compute the `deps` file for odocmkgen, for now by calling `odoc compile-deps` but it is to be computed directly by 'prep'.
This is currently not using `usexp` and `psexp` informations computed by 'prep'.