### PR TITLE
Produce pages when failures are encountered

### DIFF
--- a/src/voodoo-do/do.ml
+++ b/src/voodoo-do/do.ml
@@ -3,11 +3,11 @@
 open Voodoo_lib
 open Cmdliner
 
-let run package blessed switch redirect =
+let run package blessed switch redirect failed =
   Opam.switch := switch;
   match package with
   | None -> Do.run_all ()
-  | Some p -> Do.run p blessed redirect
+  | Some p -> Do.run p blessed redirect failed
 
 let package =
   let doc = "Select the package to process" in
@@ -30,9 +30,13 @@ let gen_redirect =
   in
   Arg.(value & flag & info [ "r"; "redirect" ] ~doc)
 
+let failed =
+  let doc = "Indicate that the build was a failed" in
+  Arg.(value & flag & info [ "failed" ] ~doc)
+
 let cmd =
   let doc = "Process a prepped package" in
-  ( Term.(const run $ package $ blessed $ switch $ gen_redirect),
+  ( Term.(const run $ package $ blessed $ switch $ gen_redirect $ failed),
     Term.info "voodoo-do" ~doc ~exits:Term.default_exits )
 
 let () = Term.(exit @@ eval cmd)

--- a/src/voodoo-gen/bin/main.ml
+++ b/src/voodoo-gen/bin/main.ml
@@ -75,6 +75,11 @@ let generate_pkgver output name_filter version_filter =
       Format.eprintf "%d other versons, %d packages\n%!" (List.length vs)
         (List.length pkgs);
       let handle_package (pkg_path, blessed, pkg_name, ver) =
+        let failed =
+          Bos.OS.File.exists Fpath.(pkg_path / "failed") |> function
+          | Ok x -> x
+          | _ -> false
+        in
         match
           Bos.OS.Dir.fold_contents ~elements:`Files ~dotfiles:false
             (fun p files ->
@@ -107,7 +112,7 @@ let generate_pkgver output name_filter version_filter =
             if blessed then
               Bos.OS.File.write
                 Fpath.(foutput / "packages" / pkg_name / ver / "status.json")
-                {|"Built"|}
+                (if failed then {|"Failed"|} else {|"Built"|})
               |> get_ok
       in
 

--- a/src/voodoo-gen/generator.ml
+++ b/src/voodoo-gen/generator.ml
@@ -601,7 +601,11 @@ module Page = struct
     in
     match List.rev (inner url) with
     | [] -> None
-    | xs -> Some (xs, String.capitalize_ascii (Format.asprintf "%a" Odoc_document.Url.Path.pp_kind url.kind))
+    | xs ->
+        Some
+          ( xs,
+            String.capitalize_ascii
+              (Format.asprintf "%a" Odoc_document.Url.Path.pp_kind url.kind) )
 
   and page indent ({ Page.title; header; items = i; url } as p) =
     let resolve = Link.Current url in

--- a/src/voodoo-gen/hrefs.ml
+++ b/src/voodoo-gen/hrefs.ml
@@ -2,9 +2,7 @@ module Urls = struct
   type leaf = File | Container_page
 
   let of_simple_list leaf l =
-    let leaf_ty =
-      match leaf with File -> `File | Container_page -> `Page
-    in
+    let leaf_ty = match leaf with File -> `File | Container_page -> `Page in
     let rec inner = function
       | [] -> failwith "Bad path"
       | [ x ] -> [ (leaf_ty, x) ]
@@ -13,8 +11,7 @@ module Urls = struct
     let l = inner l in
     match Odoc_document.Url.Path.of_list l with
     | Some l -> l
-    | None ->
-        failwith "Fatal error"
+    | None -> failwith "Fatal error"
 
   let package_page pkgname =
     of_simple_list Container_page [ "packages"; pkgname ]
@@ -38,9 +35,7 @@ end
 
 module Hrefs = struct
   let to_href ~url dest_page =
-    let dest_url =
-      Odoc_document.Url.from_path dest_page
-    in
+    let dest_url = Odoc_document.Url.from_path dest_page in
     Link.href ~resolve:(Current url) dest_url
 
   let package_json pkgname url = to_href ~url (Urls.package_json pkgname)

--- a/src/voodoo-gen/link.ml
+++ b/src/voodoo-gen/link.ml
@@ -2,44 +2,43 @@ module Url = Odoc_document.Url
 
 (* Translation from Url.Path *)
 module Path = struct
-    let flat = ref false
-    let for_printing url = List.map snd @@ Url.Path.to_list url
-  
-    let segment_to_string (kind, name) =
-      match kind with
-      | `Module | `Page -> name
-      | _ -> Format.asprintf "%a-%s" Url.Path.pp_kind kind name
-  
-    let is_leaf_page url = url.Url.Path.kind = `LeafPage
-  
-    let get_dir_and_file url =
-      let l = Url.Path.to_list url in
-      let is_dir =
-        if !flat then function `Page -> true | _ -> false
-        else function `LeafPage -> false | `File -> false | _ -> true
-      in
-      let dir, file = Url.Path.split ~is_dir l in
-      let dir = List.map segment_to_string dir in
-      let file =
-        match file with
-        | [] -> "index.html"
-        | [ (`LeafPage, name) ] -> name ^ ".html"
-        | [ (`File, name) ] -> name
-        | xs ->
-            assert !flat;
-            String.concat "-" (List.map segment_to_string xs) ^ ".html"
-      in
-      (dir, file)
-  
-    let for_linking url =
-      let dir, file = get_dir_and_file url in
-      dir @ [ file ]
-  
-    let as_filename (url : Url.Path.t) =
-      Fpath.(v @@ String.concat Fpath.dir_sep @@ for_linking url)
-  end
-  
+  let flat = ref false
 
+  let for_printing url = List.map snd @@ Url.Path.to_list url
+
+  let segment_to_string (kind, name) =
+    match kind with
+    | `Module | `Page -> name
+    | _ -> Format.asprintf "%a-%s" Url.Path.pp_kind kind name
+
+  let is_leaf_page url = url.Url.Path.kind = `LeafPage
+
+  let get_dir_and_file url =
+    let l = Url.Path.to_list url in
+    let is_dir =
+      if !flat then function `Page -> true | _ -> false
+      else function `LeafPage -> false | `File -> false | _ -> true
+    in
+    let dir, file = Url.Path.split ~is_dir l in
+    let dir = List.map segment_to_string dir in
+    let file =
+      match file with
+      | [] -> "index.html"
+      | [ (`LeafPage, name) ] -> name ^ ".html"
+      | [ (`File, name) ] -> name
+      | xs ->
+          assert !flat;
+          String.concat "-" (List.map segment_to_string xs) ^ ".html"
+    in
+    (dir, file)
+
+  let for_linking url =
+    let dir, file = get_dir_and_file url in
+    dir @ [ file ]
+
+  let as_filename (url : Url.Path.t) =
+    Fpath.(v @@ String.concat Fpath.dir_sep @@ for_linking url)
+end
 
 let semantic_uris = ref false
 

--- a/src/voodoo-gen/metadata.ml
+++ b/src/voodoo-gen/metadata.ml
@@ -41,8 +41,7 @@ let package_url name : Link.Url.t =
       {
         kind = `Page;
         name;
-        parent =
-          Some { kind = `Page; name = "packages"; parent = None };
+        parent = Some { kind = `Page; name = "packages"; parent = None };
       };
     anchor = "";
     kind = `Page;

--- a/src/voodoo-prep/main.ml
+++ b/src/voodoo-prep/main.ml
@@ -11,11 +11,11 @@ let process_package : Fpath.t -> Package.t -> Fpath.t list -> unit =
   let dest = Package.prep_path package in
 
   (* Some packages produce ocaml artefacts that can't be processed with the switch's
-      ocaml compiler - most notably the secondary compiler! This switch is intended to 
+      ocaml compiler - most notably the secondary compiler! This switch is intended to
       be used to ignore those files *)
   let process_ocaml_artefacts =
-    let (_, name, _) = package in
-    let package_blacklist = ["ocaml-secondary-compiler"] in
+    let _, name, _ = package in
+    let package_blacklist = [ "ocaml-secondary-compiler" ] in
     not (List.mem name package_blacklist)
   in
 
@@ -25,22 +25,22 @@ let process_package : Fpath.t -> Package.t -> Fpath.t list -> unit =
     in
 
     (* Menhir puts a dune build dir into docs for some reason *)
-    let in_build_dir =
-      List.exists (fun x -> x = "_build") (Fpath.segs fpath)
-    in
+    let in_build_dir = List.exists (fun x -> x = "_build") (Fpath.segs fpath) in
 
     let _, filename = Fpath.split_base fpath in
     let ext = Fpath.get_ext filename in
     let no_ext = Fpath.rem_ext filename in
-    let is_module = process_ocaml_artefacts && List.mem ext [ ".cmt"; ".cmti"; ".cmi" ] in
+    let is_module =
+      process_ocaml_artefacts && List.mem ext [ ".cmt"; ".cmti"; ".cmi" ]
+    in
     let do_copy =
-      (not in_build_dir) &&
-      (is_in_doc_dir || is_module
-      || List.mem no_ext (List.map Fpath.v [ "META"; "dune-package" ]))
+      (not in_build_dir)
+      && (is_in_doc_dir || is_module
+         || List.mem no_ext (List.map Fpath.v [ "META"; "dune-package" ]))
     in
     let is_cma = process_ocaml_artefacts && List.mem ext [ ".cma"; ".cmxa" ] in
     let copy =
-      if  do_copy then Fpath.(root // fpath, dest // fpath) :: acc.copy
+      if do_copy then Fpath.(root // fpath, dest // fpath) :: acc.copy
       else acc.copy
     in
     let info = if is_module then fpath :: acc.info else acc.info in

--- a/src/voodoo-prep/opam.ml
+++ b/src/voodoo-prep/opam.ml
@@ -51,13 +51,15 @@ let pkg_contents pkg =
     OpamStd.String.Map.fold
       (fun file x acc ->
         match x with
-        | OpamDirTrack.Added _ -> begin
+        | OpamDirTrack.Added _ -> (
             try
-              if not @@ Sys.is_directory Fpath.(to_string (prefix // v file)) then
-                file :: acc
+              if not @@ Sys.is_directory Fpath.(to_string (prefix // v file))
+              then file :: acc
               else acc
-            with _ -> acc (* dose (and maybe others) sometimes creates a symlink to something that doesn't exist *)
-          end
+            with _ ->
+              acc
+              (* dose (and maybe others) sometimes creates a symlink to something that doesn't exist *)
+            )
         | _ -> acc)
       changed []
   in

--- a/src/voodoo/error_log.ml
+++ b/src/voodoo/error_log.ml
@@ -1,0 +1,12 @@
+(* Pull out error log *)
+
+type t = string list option
+
+let find package =
+  let path = Fpath.(Package.prep_path package / "opam.error.log") in
+  try
+    let ic = open_in (Fpath.to_string path) in
+    let result = Some (Util.lines_of_channel ic) in
+    close_in ic;
+    result
+  with _ -> None


### PR DESCRIPTION
Rough and ready PR to create a page with the error log on when `voodoo-do` is invoked with `--failed`