### PR TITLE
Fix module docs link in library with no explicit interface

### DIFF
--- a/src/voodoo/package_info.ml
+++ b/src/voodoo/package_info.ml
@@ -26,9 +26,7 @@ let gen ~output ~(dune : Dune.t option) ~libraries () =
   let dune_modules = function
     | Dune.Library.Singleton m -> [ m ]
     | Unwrapped { modules; _ } -> modules
-    | Wrapped { alias_module; main_module_name; modules } ->
-        if Util.is_hidden alias_module then [ main_module_name ]
-        else List.map (fun s -> main_module_name ^ "." ^ s) modules
+    | Wrapped { main_module_name; _ } -> [ main_module_name ]
   in
   let libraries =
     match dune with


### PR DESCRIPTION
Voodoo needs to be consistent about the URL where it serves the module docs of a library and the URL where it requests them. For the serve URL, it always uses the module structure as given by dune. However, for the request URL, it used to use an unwrapped version of the module structure whenever the library doesn't have an explicit library interface. That's why this commit removes that unwrapping of the module structure.

Side-note: We're quite confident that the distinction we've removed was only introduced by copying code from the context of the version index page. On the version index page, it makes sense to have that distinction: if a library doesn't have a library interface, all its modules are exposed and so it's desirable to have all its modules on the index page and not only the wrapper module.

This fixes https://github.com/ocaml/v3.ocaml.org-server/issues/232. I've pair-programmed on this with @jonludlam.