### PR TITLE
use pandoc to parse .org files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
     (>= 4.08.0))
   (omd
    (>= 2.0.0~alpha2))
+  pandoc
   voodoo-lib
   (odoc
    (>= 2.1.0))

--- a/src/voodoo-gen/rendering.ml
+++ b/src/voodoo-gen/rendering.ml
@@ -91,14 +91,22 @@ let render_markdown ~id ~output doc =
   | Ok page -> render_document ~output page
   | Error _ -> render_text ~id ~output doc
 
+let render_org ~id ~output doc =
+  let url = Odoc_document.Url.Path.from_identifier id in
+  match Markdown.read_org doc url with
+  | Ok page -> render_document ~output page
+  | Error _ -> render_text ~id ~output doc
+
 let render_other ~output ~parent ~otherdocs =
   docs_ids parent otherdocs >>= fun docs ->
   let errors =
     List.fold_left
       (fun acc (id, doc) ->
         let result =
-          if Fpath.get_ext doc = ".md" then render_markdown ~output ~id doc
-          else render_text ~output ~id doc
+          match Fpath.get_ext doc with
+          | ".md" -> render_markdown ~output ~id doc
+          | ".org" -> render_org ~output ~id doc
+          | _ -> render_text ~output ~id doc
         in
         match result with Ok _ -> acc | Error (`Msg m) -> (doc, m) :: acc)
       [] docs

--- a/src/voodoo-gen/rendering.ml
+++ b/src/voodoo-gen/rendering.ml
@@ -12,13 +12,13 @@ let document_of_odocl ~syntax input =
   | Unit_content odoctree ->
       Ok (Renderer.document_of_compilation_unit ~syntax odoctree)
 
-let render_document ~output:root_dir odoctree =
+let render_document ~output odoctree =
   let aux pages =
-    Odoc_document.Renderer.traverse pages ~f:(fun filename content ->
-        let filename = Fpath.normalize @@ Fs.File.append root_dir filename in
-        let directory = Fs.File.dirname filename in
+    Odoc_document.Renderer.traverse pages ~f:(fun file_path content ->
+        let output_path = output file_path in
+        let directory = Fs.File.dirname output_path in
         Fs.Directory.mkdir_p directory;
-        let oc = open_out (Fs.File.to_string filename) in
+        let oc = open_out (Fs.File.to_string output_path) in
         let fmt = Format.formatter_of_out_channel oc in
         Format.fprintf fmt "%t@?" content;
         close_out oc)

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
   "omd" {>= "2.0.0~alpha2"}
+  "pandoc"
   "voodoo-lib"
   "odoc" {>= "2.1.0"}
   "opam-format" {>= "2.1.0~beta2"}
@@ -36,3 +37,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
+pin-depends: [
+  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#main"]
+]

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -38,5 +38,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
 pin-depends: [
-  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#main"]
+  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
 ]

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#main"]
+  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
 ]

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#main"]
+]


### PR DESCRIPTION
This is my attempt at addressing https://github.com/ocaml/ocaml.org/issues/30

Some packages (e.g [base](https://github.com/janestreet/base/blob/master/README.org)) don't use Markdown but the `org-mode` syntax for their `readme`. 

Even if on the `ocaml.org` side we support showing a `README.org` file, the HTML output is not nice:

![image](https://user-images.githubusercontent.com/5595092/164539624-ea250e72-2f73-499c-9adc-89b6af65765f.png)

To improve that, we could create our own `org` parser or re-use an existing one, https://github.com/whirm/mlorg or https://github.com/logseq/mldoc for example. Correct me if I'm wrong, but I don't think that creating our own parser or re-using an existing one (supposing that it would fit our needs) would be trivial. Even if we manage to produce an AST, we would still have to transform it to HTML format.

That's why I chose to use `pandoc`. `.org` files are converted to `.md` with `pandoc`, and from there we can re-use the existing workflow. Here's what the example above would look like with that PR:



https://user-images.githubusercontent.com/5595092/164541980-044e7bdd-c472-491b-bbf6-f93d4b7de729.mov


Does it sound like a reasonable approach? Note that I only tested the `README.org` file from `base`