### PR TITLE
voodoo-gen: lock `omd` version

### DIFF
--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/jonludlam/voodoo/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
-  "omd" {>= "2.0.0~alpha2"}
+  "omd" {= "2.0.0~alpha2"}
   "pandoc"
   "voodoo-lib"
   "odoc" {>= "2.1.0"}


### PR DESCRIPTION
@sabine 