### PR TITLE
Replace dependency on pandoc with a depext

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,6 @@
     (>= 4.08.0))
   (omd
    (>= 2.0.0~alpha2))
-  pandoc
   voodoo-lib
   (odoc
    (>= 2.1.0))

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
   "omd" {= "2.0.0~alpha2"}
-  "pandoc"
   "voodoo-lib"
   "odoc" {>= "2.1.0"}
   "opam-format" {>= "2.1.0~beta2"}
@@ -37,6 +36,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
-pin-depends: [
-  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
+depexts: [
+  ["pandoc"]
 ]

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,3 +1,3 @@
-pin-depends: [
-  ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
+depexts: [
+  ["pandoc"]
 ]


### PR DESCRIPTION
pandoc is a widely available system package on many platforms, so we can replace the dependency on the opam package that provides the pre-built binary with a depext