### PR TITLE
Specify the version of odoc here, instead of in the pipeline

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,11 +41,11 @@
   (ocaml
     (>= 4.08.0))
   (omd
-   (>= 2.0.0~alpha2))
+   (= 2.0.0~alpha2))
   pandoc
   voodoo-lib
   (odoc
-   (>= 2.1.0))
+   (= 2.1.0))
   (opam-format
    (>= 2.1.0~beta2))
   tyxml

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "voodoo-lib"
   "voodoo-web"
-  "odoc"
+  "odoc" {= "2.1.1"}
   "tyxml"
   "astring"
   "cmdliner"

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -39,4 +39,5 @@ build: [
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
 pin-depends: [
   ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
+  ["odoc.2.1.1" "git+https://github.com/ocaml/odoc.git#f556f10aa67f80e83d1e3e66c4b478e8efe4e18d"]
 ]

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,3 +1,4 @@
 pin-depends: [
   ["pandoc.dev" "git+https://github.com/tatchi/opam-pandoc-bin#5eeb415c7023323045371ad803f88365c7003b38"]
+  ["odoc.2.1.1" "git+https://github.com/ocaml/odoc.git#f556f10aa67f80e83d1e3e66c4b478e8efe4e18d"]
 ]

--- a/voodoo-prep.opam
+++ b/voodoo-prep.opam
@@ -14,7 +14,7 @@ depends: [
   "fpath"
   "bos"
   "opam-format"
-  "odoc" {with-doc}
+  "odoc" {= "2.1.1" with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Separation of concerns between the pipeline and voodoo suggests that we should pin the odoc version voodoo uses here, so that the pipeline doesn't have to pin the odoc version.

While we do not have voodoo wrapped up for reproducible builds (see https://github.com/ocaml-doc/voodoo/issues/49), we at least can get rid of the pipeline pinning odoc (see sibling PR https://github.com/ocurrent/ocaml-docs-ci/pull/93)