### PR TITLE
odoc must be lower bound as long as pipeline pins odoc

### DIFF
--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "omd" {= "2.0.0~alpha3"}
   "voodoo-lib"
-  "odoc" {= "2.2.0"}
+  "odoc" {>= "2.2.0"}
   "opam-format" {>= "2.1.0~beta2"}
   "tyxml"
   "astring"


### PR DESCRIPTION
The pin for odoc on the pipeline makes `odoc` install as `dev`, so voodoo will only be able to require exact versions after the pipeline no longer pins odoc.