### PR TITLE
Pin odoc.2.2.0 version.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
 version=0.24.1
+ocaml-version = 4.08.0

--- a/dune-project
+++ b/dune-project
@@ -54,6 +54,7 @@
   (opam-format
    (>= 2.1.0~beta2))
   tyxml
+  conf-pandoc
   astring
   cmdliner
   yojson

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (depends
   voodoo-lib
   voodoo-web
-  odoc ; = 2.2.0 pinned by the pipeline
+  (odoc (= 2.2.0))
   tyxml
   astring
   cmdliner
@@ -50,7 +50,7 @@
   (omd
    (= 2.0.0~alpha3))
    voodoo-lib
-  odoc  ; = 2.2.0 pinned by the pipeline
+  (odoc (= 2.2.0))
   (opam-format
    (>= 2.1.0~beta2))
   tyxml

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "voodoo-lib"
   "voodoo-web"
-  "odoc"
+  "odoc" {= "2.2.0"}
   "tyxml"
   "astring"
   "cmdliner"

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -16,6 +16,7 @@ depends: [
   "odoc" {= "2.2.0"}
   "opam-format" {>= "2.1.0~beta2"}
   "tyxml"
+  "conf-pandoc"
   "astring"
   "cmdliner"
   "yojson"
@@ -39,6 +40,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
-depexts: [
-  ["pandoc"]
-]

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "omd" {= "2.0.0~alpha3"}
   "voodoo-lib"
-  "odoc"
+  "odoc" {= "2.2.0"}
   "opam-format" {>= "2.1.0~beta2"}
   "tyxml"
   "astring"

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -40,3 +40,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jonludlam/voodoo.git"
+available: [ os-distribution != "alpine" & arch != "ppc64"]
+# PPC64 fails to build with stack overflow see https://github.com/ocaml/ocaml/issues/11415
+# Alpine-3.16 doesn't have a pandoc package, however 3.17 does

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,0 +1,3 @@
+available: [ os-distribution != "alpine" & arch != "ppc64"]
+# PPC64 fails to build with stack overflow see https://github.com/ocaml/ocaml/issues/11415
+# Alpine-3.16 doesn't have a pandoc package, however 3.17 does

--- a/voodoo-gen.opam.template
+++ b/voodoo-gen.opam.template
@@ -1,3 +1,0 @@
-depexts: [
-  ["pandoc"]
-]


### PR DESCRIPTION
Remove the need to pin this version in [ocaml-docs-ci](https://github.com/ocurrent/ocaml-docs-ci).