### PR TITLE
Fix incomplete search index

### DIFF
--- a/src/voodoo-gen/search_index.ml
+++ b/src/voodoo-gen/search_index.ml
@@ -302,7 +302,12 @@ module Load_doc = struct
     | None -> ()
     | Some mt_expr -> module_type_expr ppf mt_expr
 
-  and simple_expansion _ppf _s_e = ()
+  and simple_expansion ppf s_e =
+    match s_e with
+    | ModuleType.Signature sg -> signature ppf sg
+    | Functor (param, s_e) ->
+        let () = functor_parameter ppf param in
+        simple_expansion ppf s_e
 
   and module_type_expr ppf mte =
     match mte with

--- a/src/voodoo-gen/search_index.ml
+++ b/src/voodoo-gen/search_index.ml
@@ -102,7 +102,7 @@ module Generate = struct
    fun n ->
     match full_name_aux (n :> Odoc_model.Paths.Identifier.t) with
     | [] -> ""
-    | _ :: q -> String.concat "." q
+    | _ :: q -> String.concat "." (List.rev q)
 
   let string_of_entry { id; doc } =
     Odoc_document.Url.from_identifier ~stop_before:false id >>= fun url ->


### PR DESCRIPTION
Simple expansions were ignored during the traverse of `.odocl` file (introduced in #58), resulting in an incomplete search index.