### PR TITLE
Revert "Pin odoc.2.2.0 version."

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,1 @@
 version=0.24.1
-ocaml-version = 4.08.0

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (depends
   voodoo-lib
   voodoo-web
-  (odoc (= 2.2.0))
+  odoc ; = 2.2.0 pinned by the pipeline
   tyxml
   astring
   cmdliner
@@ -50,7 +50,7 @@
   (omd
    (= 2.0.0~alpha3))
    voodoo-lib
-  (odoc (= 2.2.0))
+  odoc  ; = 2.2.0 pinned by the pipeline
   (opam-format
    (>= 2.1.0~beta2))
   tyxml

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "voodoo-lib"
   "voodoo-web"
-  "odoc" {= "2.2.0"}
+  "odoc"
   "tyxml"
   "astring"
   "cmdliner"

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "omd" {= "2.0.0~alpha3"}
   "voodoo-lib"
-  "odoc" {= "2.2.0"}
+  "odoc"
   "opam-format" {>= "2.1.0~beta2"}
   "tyxml"
   "conf-pandoc"


### PR DESCRIPTION
This reverts commit dbd9b7d9b2c14fd0119bf2a0992936cd480fa9d9 in line with https://github.com/ocurrent/ocaml-docs-ci/pull/116. We'll disentangle voodoo and the pipeline on the staging environment first.