### PR TITLE
List "other" doc files info (README, LICENSE, CHANGES) in status.json

### DIFF
--- a/test/can-render-org-files.t
+++ b/test/can-render-org-files.t
@@ -5,7 +5,7 @@ Generate the base documentation
   $ voodoo-do -p base -b 2> /dev/null
 
   $ voodoo-gen -o output
-  0 other versons, 1 packages
+  0 other versions, 1 packages
   Found 6 files
   Warning, resolved hidden path: Base__.Hash_set_intf.M_sexp_grammar
   Warning, resolved hidden path: Base__.Hash_set_intf.M_sexp_grammar
@@ -15,8 +15,25 @@ Generate the base documentation
   Warning, resolved hidden path: Base__.Either0.t
 
 Generates a status.json file
-  $ cat output/p/base/v0.15.1/status.json
-  ["Built"]
+  $ cat output/p/base/v0.15.1/status.json | jq .
+  {
+    "failed": false,
+    "otherdocs": {
+      "readme": [
+        "linked/p/base/v0.15.1/doc/README.org",
+        "linked/p/base/v0.15.1/doc/README.md"
+      ],
+      "license": [
+        "linked/p/base/v0.15.1/doc/LICENSE.md"
+      ],
+      "changes": [
+        "linked/p/base/v0.15.1/doc/CHANGES.md"
+      ],
+      "others": [
+        "linked/p/base/v0.15.1/package.json"
+      ]
+    }
+  }
 
 Converted the README.org file in markdown
   $ ls output/p/base/v0.15.1/

--- a/test/can-render-tables.t
+++ b/test/can-render-tables.t
@@ -5,12 +5,28 @@ Generate the ppx_deriving_yaml documentation
   $ voodoo-do -p ppx_deriving_yaml -b 2> /dev/null
 
   $ voodoo-gen -o output
-  0 other versons, 1 packages
+  0 other versions, 1 packages
   Found 2 files
 
 Generates a status.json file
-  $ cat output/p/ppx_deriving_yaml/0.2.1/status.json
-  ["Built"]
+  $ cat output/p/ppx_deriving_yaml/0.2.1/status.json | jq .
+  {
+    "failed": false,
+    "otherdocs": {
+      "readme": [
+        "linked/p/ppx_deriving_yaml/0.2.1/doc/README.md"
+      ],
+      "license": [
+        "linked/p/ppx_deriving_yaml/0.2.1/doc/LICENSE.md"
+      ],
+      "changes": [
+        "linked/p/ppx_deriving_yaml/0.2.1/doc/CHANGES.md"
+      ],
+      "others": [
+        "linked/p/ppx_deriving_yaml/0.2.1/package.json"
+      ]
+    }
+  }
 
 Generate a README.md file with the tables formatted in HTML
   $ cat output/p/ppx_deriving_yaml/0.2.1/README.md.html.json | jq '.content'


### PR DESCRIPTION
Suggested by @sabine

Based on #67 to simplify writing in the package.json file