### PR TITLE
Add voodoo_lib in dune libraries

### DIFF
--- a/src/voodoo-gen/dune
+++ b/src/voodoo-gen/dune
@@ -3,4 +3,13 @@
  (public_name voodoo-gen.odoc_thtml)
  (preprocess
   (pps ppx_yojson_conv))
- (libraries odoc.model odoc.document odoc.odoc omd tyxml bos yojson ppx_yojson_conv))
+ (libraries
+  odoc.model
+  odoc.document
+  odoc.odoc
+  omd
+  tyxml
+  bos
+  voodoo_lib
+  yojson
+  ppx_yojson_conv))


### PR DESCRIPTION
In https://github.com/ocaml-doc/voodoo/commit/be10e78f8af15633a868f2c5e9deb7b807df4788, I accidentally removed `voodoo_lib` from `voodoo-gen/dune`.