### PR TITLE
Clean error when running voodoo-do on an uninstalled package

### DIFF
--- a/dune
+++ b/dune
@@ -1,9 +1,9 @@
 (rule
  (with-stdout-to
-  dune-project.formatted
+  dune-project.1
   (run dune format-dune-file dune-project)))
 
 (rule
  (alias fmt)
  (action
-  (diff dune-project dune-project.formatted)))
+  (diff dune-project dune-project.1)))

--- a/dune-project
+++ b/dune-project
@@ -21,19 +21,36 @@
  (name voodoo-lib)
  (synopsis "Voodoo library")
  (description "Voodoo library")
- (depends bos astring fpath opam-format ppx_yojson_conv sexplib yojson))
+ (depends
+  (ocaml
+    (>= 4.08.0))
+  bos
+  astring
+  fpath
+  opam-format
+  ppx_yojson_conv
+  sexplib
+  yojson))
 
 (package
  (name voodoo-prep)
  (synopsis "Voodoo prep")
  (description "Voodoo prep")
- (depends cmdliner fpath bos opam-format))
+ (depends 
+  (ocaml
+    (>= 4.08.0))
+  cmdliner
+  fpath
+  bos
+  opam-format))
 
 (package
  (name voodoo-do)
  (synopsis "Voodoo compilation step")
  (description "Voodoo compilation step")
  (depends
+  (ocaml
+    (>= 4.08.0))
   voodoo-lib
   odoc ; = 2.2.0 pinned by the pipeline
   tyxml

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
  (description "Voodoo library")
  (depends
   (ocaml
-    (>= 4.08.0))
+   (>= 4.08.0))
   bos
   astring
   fpath
@@ -36,9 +36,9 @@
  (name voodoo-prep)
  (synopsis "Voodoo prep")
  (description "Voodoo prep")
- (depends 
+ (depends
   (ocaml
-    (>= 4.08.0))
+   (>= 4.08.0))
   cmdliner
   fpath
   bos
@@ -50,7 +50,7 @@
  (description "Voodoo compilation step")
  (depends
   (ocaml
-    (>= 4.08.0))
+   (>= 4.08.0))
   voodoo-lib
   odoc ; = 2.2.0 pinned by the pipeline
   tyxml

--- a/src/voodoo/do.ml
+++ b/src/voodoo/do.ml
@@ -85,7 +85,7 @@ let package_info_of_fpath p =
       failwith "Bad path"
 
 let find_universe_and_version pkg_name =
-  let ( >>= ) = Result.bind in
+  let ( >>= ) = Stdlib.Result.bind in
   Bos.OS.Dir.contents Fpath.(Paths.prep / "universes") >>= fun universes ->
   let universe =
     match

--- a/src/voodoo/do.ml
+++ b/src/voodoo/do.ml
@@ -85,23 +85,25 @@ let package_info_of_fpath p =
       failwith "Bad path"
 
 let find_universe_and_version pkg_name =
-  let universes =
-    Bos.OS.Dir.contents Fpath.(Paths.prep / "universes") |> Util.get_ok
+  let ( >>= ) = Result.bind in
+  Bos.OS.Dir.contents Fpath.(Paths.prep / "universes") >>= fun universes ->
+  let universe =
+    match
+      List.find_opt
+        (fun u ->
+          match Bos.OS.Dir.exists Fpath.(u / pkg_name) with
+          | Ok b -> b
+          | Error _ -> false)
+        universes
+    with
+    | Some u -> Ok u
+    | None -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
   in
-  let u =
-    List.find
-      (fun u ->
-        match Bos.OS.Dir.exists Fpath.(u / pkg_name) with
-        | Ok b -> b
-        | Error _ -> false)
-      universes
-  in
-  let version =
-    Bos.OS.Dir.contents ~rel:true Fpath.(u / pkg_name) |> Util.get_ok
-  in
+  universe >>= fun u ->
+  Bos.OS.Dir.contents ~rel:true Fpath.(u / pkg_name) >>= fun version ->
   match (Fpath.segs u, version) with
-  | _ :: _ :: u :: _, [ version ] -> Some (u, Fpath.to_string version)
-  | _ -> None
+  | _ :: _ :: u :: _, [ version ] -> Ok (u, Fpath.to_string version)
+  | _ -> Error (`Msg (Format.sprintf "Failed to find package %s" pkg_name))
 
 let run pkg_name is_blessed failed =
   let is_interesting p =
@@ -119,9 +121,9 @@ let run pkg_name is_blessed failed =
 
   let universe, version =
     match find_universe_and_version pkg_name with
-    | Some x -> x
-    | None ->
-        Format.eprintf "Failed to find package\n%!";
+    | Ok x -> x
+    | Error (`Msg e) ->
+        Format.eprintf "%s\n%!" e;
         exit 1
   in
 

--- a/test/uninstalled_package.t
+++ b/test/uninstalled_package.t
@@ -1,0 +1,7 @@
+Call voodoo-do on an uninstalled package
+
+  $ voodoo-prep 2> /dev/null
+
+  $ voodoo-do -p albatross -b
+  Failed to find package albatross
+  [1]

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -10,6 +10,7 @@ homepage: "https://github.com/jonludlam/voodoo"
 bug-reports: "https://github.com/jonludlam/voodoo/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
   "voodoo-lib"
   "odoc"
   "tyxml"

--- a/voodoo-lib.opam
+++ b/voodoo-lib.opam
@@ -10,6 +10,7 @@ homepage: "https://github.com/jonludlam/voodoo"
 bug-reports: "https://github.com/jonludlam/voodoo/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
   "bos"
   "astring"
   "fpath"

--- a/voodoo-prep.opam
+++ b/voodoo-prep.opam
@@ -10,6 +10,7 @@ homepage: "https://github.com/jonludlam/voodoo"
 bug-reports: "https://github.com/jonludlam/voodoo/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
   "cmdliner"
   "fpath"
   "bos"


### PR DESCRIPTION
Fix #38

Catch the `Not_found` exception, and use a Result type instead of an Option to carry the error message.

Needs to be rebased on #65 