### PR TITLE
Require ppx_yojson_conv v0.15.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,7 @@
   cmdliner
   yojson
   bos
-  ppx_yojson_conv
+  (ppx_yojson_conv (= v0.15.1))
   sexplib
   fpath
   (ppx_deriving_yaml :with-test)))

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -20,7 +20,7 @@ depends: [
   "cmdliner"
   "yojson"
   "bos"
-  "ppx_yojson_conv"
+  "ppx_yojson_conv" {= "v0.15.1"}
   "sexplib"
   "fpath"
   "ppx_deriving_yaml" {with-test}


### PR DESCRIPTION
```
$ make
opam exec -- dune build --root . @install
File "src/voodoo/package_info.ml", line 6, characters 9-15:
6 |   name : string;
             ^^^^^^
Error: Unbound value string_of_yojson
make: *** [Makefile:8: all] Error 1   
```

`ppx_yojson_conv` had a release last week, and voodoo broke while running on `ocaml-docs-ci`.

We really need to dockerize voodoo or at least install voodoo from opam lock file, so that we don't lose a build to such breakages.
