### PR TITLE
CI: mark dune-project as a dependence of the fmt rule

### DIFF
--- a/dune
+++ b/dune
@@ -1,7 +1,7 @@
 (rule
  (with-stdout-to
   dune-project.1
-  (run dune format-dune-file dune-project)))
+  (run dune format-dune-file %{dep:dune-project})))
 
 (rule
  (alias fmt)


### PR DESCRIPTION
Trying to fix this error on the CI:
```
File "dune", line 1, characters 0-84:
1 | (rule
2 |  (with-stdout-to
3 |   dune-project.1
4 |   (run dune format-dune-file dune-project)))
(cd _build/default && /Users/runner/work/voodoo/voodoo/_opam/bin/dune format-dune-file dune-project) > _build/default/dune-project.1
Error: /Users/runner/work/voodoo/voodoo/_build/default/dune-project: No such
file or directory
Error: Process completed with exit code 1.
```

From the "CI / build-and-test" check