### PR TITLE
Replace ppx_yojson_conv with ppx_deriving_yojson

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   bos
   astring
   fpath
-  ppx_yojson_conv
+  ppx_deriving_yojson
   sexplib
   yojson))
 
@@ -78,8 +78,7 @@
   cmdliner
   yojson
   bos
-  (ppx_yojson_conv
-   (= v0.15.1))
+  ppx_deriving_yojson
   sexplib
   fpath
   (conf-jq :with-test)

--- a/src/voodoo-gen/dune
+++ b/src/voodoo-gen/dune
@@ -3,5 +3,5 @@
  (public_name voodoo-gen)
  (package voodoo-gen)
  (preprocess
-  (pps ppx_yojson_conv))
- (libraries voodoo_lib odoc.odoc omd bos yojson ppx_yojson_conv cmdliner))
+  (pps ppx_deriving_yojson))
+ (libraries voodoo_lib odoc.odoc omd bos yojson ppx_deriving_yojson cmdliner))

--- a/src/voodoo-gen/main.ml
+++ b/src/voodoo-gen/main.ml
@@ -131,7 +131,7 @@ let generate_pkgver output_dir name_filter version_filter =
             if Option.is_none universe then
               Yojson.Safe.to_file
                 Fpath.(output_prefix / "status.json" |> to_string)
-                (yojson_of_status status);
+                (status_to_yojson status);
 
             match
               Search_index.generate_index

--- a/src/voodoo/dune
+++ b/src/voodoo/dune
@@ -2,5 +2,5 @@
  (name voodoo_lib)
  (public_name voodoo-lib)
  (preprocess
-  (pps ppx_yojson_conv))
- (libraries astring fpath bos ppx_yojson_conv sexplib yojson))
+  (pps ppx_deriving_yojson))
+ (libraries astring fpath bos ppx_deriving_yojson sexplib yojson))

--- a/src/voodoo/package_info.ml
+++ b/src/voodoo/package_info.ml
@@ -33,4 +33,4 @@ let gen ~output ~(dune : Dune.t option) ~libraries () =
   in
 
   let output = Fpath.(to_string (output / "package.json")) in
-  Yojson.Safe.to_file output (yojson_of_t yojson_of_string { libraries })
+  Yojson.Safe.to_file output (to_yojson [%to_yojson: string] { libraries })

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -19,7 +19,7 @@ depends: [
   "cmdliner"
   "yojson"
   "bos"
-  "ppx_yojson_conv" {= "v0.15.1"}
+  "ppx_deriving_yojson"
   "sexplib"
   "fpath"
   "conf-jq" {with-test}

--- a/voodoo-lib.opam
+++ b/voodoo-lib.opam
@@ -14,7 +14,7 @@ depends: [
   "bos"
   "astring"
   "fpath"
-  "ppx_yojson_conv"
+  "ppx_deriving_yojson"
   "sexplib"
   "yojson"
   "odoc" {with-doc}


### PR DESCRIPTION
`ppx_deriving_yojson` is older but it allows us to drop the `base` dependency.