### PR TITLE
Remove "ocaml >= 4.08" dependency on voodoo-lib, voodoo-do and voodoo-prep

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,28 +20,14 @@
  (synopsis "OCaml.org's package documentation generator (library)")
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-lib is the base library.")
- (depends
-  (ocaml
-   (>= 4.08.0))
-  bos
-  astring
-  fpath
-  ppx_deriving_yojson
-  sexplib
-  yojson))
+ (depends bos astring fpath ppx_deriving_yojson sexplib yojson))
 
 (package
  (name voodoo-prep)
  (synopsis "OCaml.org's package documentation generator (preparation step)")
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-prep runs the preparation step.")
- (depends
-  (ocaml
-   (>= 4.08.0))
-  cmdliner
-  fpath
-  bos
-  opam-format))
+ (depends cmdliner fpath bos opam-format))
 
 (package
  (name voodoo-do)
@@ -49,8 +35,6 @@
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-do runs the compilation step.")
  (depends
-  (ocaml
-   (>= 4.08.0))
   voodoo-lib
   ; odoc.2.2.0 pinned by the pipeline
   (odoc

--- a/dune-project
+++ b/dune-project
@@ -46,6 +46,7 @@
   ; odoc.2.2.0 pinned by the pipeline
   (odoc
    (>= 2.2.0))
+  bos
   astring
   cmdliner
   yojson))

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,14 @@
  (synopsis "OCaml.org's package documentation generator (library)")
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-lib is the base library.")
- (depends bos astring fpath ppx_deriving_yojson sexplib yojson))
+ (depends
+  bos
+  astring
+  fpath
+  (ppx_deriving_yojson
+   (>= 3.6.0))
+  sexplib
+  yojson))
 
 (package
  (name voodoo-prep)
@@ -62,7 +69,8 @@
   cmdliner
   yojson
   bos
-  ppx_deriving_yojson
+  (ppx_deriving_yojson
+   (>= 3.6.0))
   sexplib
   fpath
   (conf-jq :with-test)

--- a/src/voodoo-do/do.ml
+++ b/src/voodoo-do/do.ml
@@ -1,7 +1,8 @@
 (* do! - perform the odoc compile and link stages *)
 
 open Voodoo_lib
-module Result = Stdlib.Result
+module Result = Bos_setup.R
+open Result.Infix
 
 module InputSelect = struct
   let order path =
@@ -88,7 +89,6 @@ let package_info_of_fpath p =
       failwith "Bad path"
 
 let find_universe_and_version pkg_name =
-  let ( >>= ) = Result.bind in
   Bos.OS.Dir.contents Fpath.(Paths.prep / "universes") >>= fun universes ->
   let universe =
     match

--- a/src/voodoo-do/dune
+++ b/src/voodoo-do/dune
@@ -2,4 +2,4 @@
  (name main)
  (public_name voodoo-do)
  (package voodoo-do)
- (libraries voodoo-lib cmdliner))
+ (libraries bos.setup voodoo-lib cmdliner))

--- a/src/voodoo/dune
+++ b/src/voodoo/dune
@@ -3,4 +3,4 @@
  (public_name voodoo-lib)
  (preprocess
   (pps ppx_deriving_yojson))
- (libraries astring fpath bos ppx_deriving_yojson sexplib yojson))
+ (libraries astring fpath bos bos.setup ppx_deriving_yojson sexplib yojson))

--- a/src/voodoo/dune.ml
+++ b/src/voodoo/dune.ml
@@ -1,5 +1,6 @@
 (* Process dune-package *)
-open Result
+module Result = Bos_setup.R
+open Result.Infix
 
 module Library = struct
   type wrapped_t = {
@@ -20,9 +21,6 @@ module Library = struct
 end
 
 type t = { name : string; version : string option; libraries : Library.t list }
-
-let ( >>= ) m f = match m with Ok v -> f v | Error e -> Error e
-let join = function Ok r -> r | Error _ as e -> e
 
 let assoc_list = function
   | Sexplib.Sexp.List ls ->
@@ -152,4 +150,4 @@ let find package =
       if name = Fpath.v "dune-package" then Ok p else acc)
     (Error (`Msg "Missing"))
     path
-  |> join
+  |> Result.join

--- a/src/voodoo/dune.mli
+++ b/src/voodoo/dune.mli
@@ -22,6 +22,5 @@ end
 
 type t = { name : string; version : string option; libraries : Library.t list }
 
-val ( >>= ) : ('a, 'b) result -> ('a -> ('c, 'b) result) -> ('c, 'b) result
 val process_file : Fpath.t -> (t, [> `Msg of string ]) result
 val find : Package.t -> (Fpath.t, [> Rresult.R.msg ]) result

--- a/src/voodoo/mld.ml
+++ b/src/voodoo/mld.ml
@@ -1,4 +1,4 @@
-module Result = Stdlib.Result
+module Result = Bos_setup.R
 
 type t = {
   path : Paths.t;

--- a/src/voodoo/util.ml
+++ b/src/voodoo/util.ml
@@ -1,5 +1,7 @@
 (* util.ml *)
 open Bos
+module Result = Bos_setup.R
+open Result.Infix
 
 let is_hidden s =
   let len = String.length s in
@@ -42,7 +44,4 @@ let mkdir_p d =
   in
   ()
 
-let copy src dst =
-  let open Result in
-  let ( >>= ) m f = match m with Ok x -> f x | Error y -> Error y in
-  Bos.OS.File.read src >>= Bos.OS.File.write dst
+let copy src dst = Bos.OS.File.read src >>= Bos.OS.File.write dst

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -10,7 +10,6 @@ homepage: "https://github.com/ocaml-doc/voodoo"
 bug-reports: "https://github.com/ocaml-doc/voodoo/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
   "voodoo-lib"
   "odoc" {>= "2.2.0"}
   "astring"

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "3.0"}
   "voodoo-lib"
   "odoc" {>= "2.2.0"}
+  "bos"
   "astring"
   "cmdliner"
   "yojson"

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -19,7 +19,7 @@ depends: [
   "cmdliner"
   "yojson"
   "bos"
-  "ppx_deriving_yojson"
+  "ppx_deriving_yojson" {>= "3.6.0"}
   "sexplib"
   "fpath"
   "conf-jq" {with-test}

--- a/voodoo-lib.opam
+++ b/voodoo-lib.opam
@@ -10,7 +10,6 @@ homepage: "https://github.com/ocaml-doc/voodoo"
 bug-reports: "https://github.com/ocaml-doc/voodoo/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
   "bos"
   "astring"
   "fpath"

--- a/voodoo-lib.opam
+++ b/voodoo-lib.opam
@@ -13,7 +13,7 @@ depends: [
   "bos"
   "astring"
   "fpath"
-  "ppx_deriving_yojson"
+  "ppx_deriving_yojson" {>= "3.6.0"}
   "sexplib"
   "yojson"
   "odoc" {with-doc}

--- a/voodoo-prep.opam
+++ b/voodoo-prep.opam
@@ -10,7 +10,6 @@ homepage: "https://github.com/ocaml-doc/voodoo"
 bug-reports: "https://github.com/ocaml-doc/voodoo/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.0"}
   "cmdliner"
   "fpath"
   "bos"


### PR DESCRIPTION
This reverts commit e8f0c37da4216324d284adaa9b39368206ac870c.

@sabine this keeps the "ocaml >= 4.08" constraint for voodoo-gen only. We need to use something else to have access to `Result` that doesn't exist in the stdlib before, so I've used `Bos_setup.R` which is already available since we already depend on `bos`.