### PR TITLE
Define Voodoo_serialize, drop ppx_deriving_yojson dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,20 +21,28 @@
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-lib is the base library.")
  (depends
+  (alcotest
+   (and
+    :with-test
+    (>= 0.7.0)))
   bos
   astring
   fpath
-  (ppx_deriving_yojson
-   (>= 3.6.0))
   sexplib
-  yojson))
+  (yojson
+   (>= 1.6.0))))
 
 (package
  (name voodoo-prep)
  (synopsis "OCaml.org's package documentation generator (preparation step)")
  (description
   "Voodoo is an odoc driver used to generate OCaml.org's package documentation. voodoo-prep runs the preparation step.")
- (depends cmdliner fpath bos opam-format))
+ (depends
+  cmdliner
+  fpath
+  bos
+  (opam-format
+   (>= 2.0.0))))
 
 (package
  (name voodoo-do)
@@ -49,7 +57,8 @@
   bos
   astring
   cmdliner
-  yojson))
+  (yojson
+   (>= 1.6.0))))
 
 (package
  (name voodoo-gen)
@@ -66,10 +75,9 @@
   conf-pandoc
   astring
   cmdliner
-  yojson
+  (yojson
+   (>= 1.6.0))
   bos
-  (ppx_deriving_yojson
-   (>= 3.6.0))
   sexplib
   fpath
   (conf-jq :with-test)))

--- a/src/voodoo-do/do.ml
+++ b/src/voodoo-do/do.ml
@@ -4,6 +4,8 @@ open Voodoo_lib
 module Result = Bos_setup.R
 open Result.Infix
 
+type ('a, 'e) result = ('a, 'e) Rresult.result = Ok of 'a | Error of 'e
+
 module InputSelect = struct
   let order path =
     let ext = Fpath.get_ext path in
@@ -92,7 +94,7 @@ let find_universe_and_version pkg_name =
   Bos.OS.Dir.contents Fpath.(Paths.prep / "universes") >>= fun universes ->
   let universe =
     match
-      List.find_opt
+      Compat.List.find_opt
         (fun u ->
           match Bos.OS.Dir.exists Fpath.(u / pkg_name) with
           | Ok b -> b

--- a/src/voodoo-gen/dune
+++ b/src/voodoo-gen/dune
@@ -2,6 +2,4 @@
  (name main)
  (public_name voodoo-gen)
  (package voodoo-gen)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries voodoo_lib odoc.odoc omd bos yojson ppx_deriving_yojson cmdliner))
+ (libraries odoc.odoc omd bos yojson cmdliner voodoo_lib))

--- a/src/voodoo/compat.ml
+++ b/src/voodoo/compat.ml
@@ -1,3 +1,7 @@
 module List = struct
   let concat_map f l = List.flatten (List.map f l)
+
+  let rec find_opt p = function
+    | [] -> None
+    | x :: l -> if p x then Some x else find_opt p l
 end

--- a/src/voodoo/compat.mli
+++ b/src/voodoo/compat.mli
@@ -1,4 +1,8 @@
 module List : sig
   val concat_map : ('a -> 'b list) -> 'a list -> 'b list
   (** [concat_map f l] gives the same result as [List.concat (List.map f l)]. *)
+
+  val find_opt : ('a -> bool) -> 'a list -> 'a option
+  (** [find_opt f l] returns the first element of the list [l] that satisfies the predicate [f].
+      Returns [None] if there is no value that satisfies [f] in the list [l]. *)
 end

--- a/src/voodoo/dune
+++ b/src/voodoo/dune
@@ -1,6 +1,4 @@
 (library
  (name voodoo_lib)
  (public_name voodoo-lib)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries astring fpath bos bos.setup ppx_deriving_yojson sexplib yojson))
+ (libraries astring fpath bos bos.setup sexplib yojson voodoo-lib.serialize))

--- a/src/voodoo/dune.ml
+++ b/src/voodoo/dune.ml
@@ -2,6 +2,8 @@
 module Result = Bos_setup.R
 open Result.Infix
 
+type ('a, 'e) result = ('a, 'e) Rresult.result = Ok of 'a | Error of 'e
+
 module Library = struct
   type wrapped_t = {
     main_module_name : string;

--- a/src/voodoo/dune.mli
+++ b/src/voodoo/dune.mli
@@ -22,5 +22,5 @@ end
 
 type t = { name : string; version : string option; libraries : Library.t list }
 
-val process_file : Fpath.t -> (t, [> `Msg of string ]) result
-val find : Package.t -> (Fpath.t, [> Rresult.R.msg ]) result
+val process_file : Fpath.t -> (t, [> `Msg of string ]) Bos_setup.result
+val find : Package.t -> (Fpath.t, [> Bos_setup.R.msg ]) Bos_setup.result

--- a/src/voodoo/ocamlobjinfo.mli
+++ b/src/voodoo/ocamlobjinfo.mli
@@ -1,2 +1,2 @@
 val process : Fpath.t list -> (string * string list) list
-val find : Package.t -> (Fpath.t list, [> Rresult.R.msg ]) result
+val find : Package.t -> (Fpath.t list, [> Bos_setup.R.msg ]) Bos_setup.result

--- a/src/voodoo/opam.mli
+++ b/src/voodoo/opam.mli
@@ -3,4 +3,4 @@ type package = { name : string; version : string }
 val switch : string option ref
 val dependencies : package -> package list
 val all_opam_packages : unit -> package list
-val find : Package.t -> (Fpath.t, [> Rresult.R.msg ]) result
+val find : Package.t -> (Fpath.t, [> Bos_setup.R.msg ]) Bos_setup.result

--- a/src/voodoo/package_info.mli
+++ b/src/voodoo/package_info.mli
@@ -1,12 +1,3 @@
-type 'a library = {
-  name : string;
-  modules : 'a list;
-  dependencies : string list option;
-}
-[@@deriving yojson]
-
-type 'a t = { libraries : 'a library list } [@@deriving yojson]
-
 val gen :
   output:Fpath.t ->
   dune:Dune.t option ->

--- a/src/voodoo/serialize/conv.ml
+++ b/src/voodoo/serialize/conv.ml
@@ -1,0 +1,2 @@
+type 'a of_yojson = Yojson.Safe.t -> 'a
+type 'a to_yojson = 'a -> Yojson.Safe.t

--- a/src/voodoo/serialize/conv.mli
+++ b/src/voodoo/serialize/conv.mli
@@ -1,0 +1,2 @@
+type 'a of_yojson = Yojson.Safe.t -> 'a
+type 'a to_yojson = 'a -> Yojson.Safe.t

--- a/src/voodoo/serialize/dune
+++ b/src/voodoo/serialize/dune
@@ -1,0 +1,4 @@
+(library
+ (name voodoo_serialize)
+ (public_name voodoo-lib.serialize)
+ (libraries fpath yojson))

--- a/src/voodoo/serialize/fpath_.ml
+++ b/src/voodoo/serialize/fpath_.ml
@@ -1,0 +1,4 @@
+type t = Fpath.t
+
+let of_yojson json = json |> Yojson.Safe.Util.to_string |> Fpath.v
+let to_yojson x = `String (Fpath.to_string x)

--- a/src/voodoo/serialize/fpath_.mli
+++ b/src/voodoo/serialize/fpath_.mli
@@ -1,0 +1,4 @@
+type t = Fpath.t
+
+val of_yojson : t Conv.of_yojson
+val to_yojson : t Conv.to_yojson

--- a/src/voodoo/serialize/package_info.ml
+++ b/src/voodoo/serialize/package_info.ml
@@ -1,0 +1,119 @@
+module Kind = struct
+  type t =
+    [ `Module
+    | `Page
+    | `LeafPage
+    | `ModuleType
+    | `Parameter of int
+    | `Class
+    | `ClassType
+    | `File ]
+
+  let to_string = function
+    | `Page -> "page"
+    | `Module -> "module"
+    | `LeafPage -> "leaf-page"
+    | `ModuleType -> "module-type"
+    | `Parameter arg_num -> Printf.sprintf "argument-%d" arg_num
+    | `Class -> "class"
+    | `ClassType -> "class-type"
+    | `File -> "file"
+
+  let of_string = function
+    | "page" -> `Page
+    | "module" -> `Module
+    | "leaf-page" -> `LeafPage
+    | "module-type" -> `ModuleType
+    | "class" -> `Class
+    | "class-type" -> `ClassType
+    | "file" -> `File
+    | s when String.length s > 9 && String.sub s 0 9 = "argument-" ->
+        let i = String.sub s 9 (String.length s - 9) in
+        `Parameter (int_of_string i)
+    | s ->
+        raise (Invalid_argument (Format.sprintf "Variant not supported: %s" s))
+
+  let equal x y = to_string x = to_string y
+  let pp fs x = Format.fprintf fs "%s" (to_string x)
+  let of_yojson json = json |> Yojson.Safe.Util.to_string |> of_string
+  let to_yojson x = `String (to_string x)
+end
+
+module Module = struct
+  type t = { name : string; submodules : t list; kind : Kind.t }
+
+  let rec equal x y =
+    x.name = y.name && Kind.equal x.kind y.kind
+    && Util.list_equal equal x.submodules y.submodules
+
+  let rec pp fs x =
+    Format.fprintf fs "(name:%S) (submodules:%a) (kind:%a)" x.name
+      (Format.pp_print_list pp) x.submodules Kind.pp x.kind
+
+  let rec of_yojson json =
+    let open Yojson.Safe.Util in
+    let name = json |> member "name" |> to_string in
+    let submodules =
+      json |> member "submodules" |> to_list |> List.map of_yojson
+    in
+    (* [Invalid_argument] is not caught on purpose. *)
+    let kind = json |> member "kind" |> Kind.of_yojson in
+    { name; submodules; kind }
+
+  let rec to_yojson { name; kind; submodules } =
+    let name = ("name", `String name) in
+    let submodules = ("submodules", `List (List.map to_yojson submodules)) in
+    let kind = ("kind", Kind.to_yojson kind) in
+    `Assoc [ name; submodules; kind ]
+end
+
+module Library = struct
+  type 'a t = { name : string; modules : 'a list; dependencies : string list }
+
+  let equal f x y =
+    x.name = y.name
+    && Util.list_equal f x.modules y.modules
+    && Util.list_equal ( = ) x.dependencies y.dependencies
+
+  let pp f fs x =
+    Format.fprintf fs "(name:%S) (modules:%a) (dependencies:%a)" x.name
+      (Format.pp_print_list f) x.modules
+      (Format.pp_print_list Format.pp_print_string)
+      x.dependencies
+
+  let of_yojson f json =
+    let open Yojson.Safe.Util in
+    let name = json |> member "name" |> to_string in
+    let modules = json |> member "modules" |> to_list |> List.map f in
+    let dependencies =
+      try json |> member "dependencies" |> to_list |> List.map to_string
+      with Type_error _ -> []
+    in
+    { name; modules; dependencies }
+
+  let to_yojson f { name; modules; dependencies } =
+    let list_string v = `List (List.map (fun m -> `String m) v) in
+    let name = ("name", `String name) in
+    let modules = ("modules", `List (List.map f modules)) in
+    let dependencies = [ ("dependencies", list_string dependencies) ] in
+    `Assoc (name :: modules :: dependencies)
+end
+
+type 'a t = { libraries : 'a Library.t list }
+
+let equal f x y = Util.list_equal (Library.equal f) x.libraries y.libraries
+
+let pp f fs x =
+  Format.fprintf fs "(libraries:%a)"
+    (Format.pp_print_list (Library.pp f))
+    x.libraries
+
+let of_yojson f json =
+  let open Yojson.Safe.Util in
+  let libraries =
+    json |> member "libraries" |> to_list |> List.map (Library.of_yojson f)
+  in
+  { libraries }
+
+let to_yojson f { libraries } =
+  `Assoc [ ("libraries", `List (List.map (Library.to_yojson f) libraries)) ]

--- a/src/voodoo/serialize/package_info.mli
+++ b/src/voodoo/serialize/package_info.mli
@@ -1,0 +1,41 @@
+module Kind : sig
+  type t =
+    [ `Module
+    | `Page
+    | `LeafPage
+    | `ModuleType
+    | `Parameter of int
+    | `Class
+    | `ClassType
+    | `File ]
+
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val of_yojson : t Conv.of_yojson
+  val to_yojson : t Conv.to_yojson
+end
+
+module Module : sig
+  type t = { name : string; submodules : t list; kind : Kind.t }
+
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val of_yojson : t Conv.of_yojson
+  val to_yojson : t Conv.to_yojson
+end
+
+module Library : sig
+  type 'a t = { name : string; modules : 'a list; dependencies : string list }
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+  val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+  val of_yojson : 'a Conv.of_yojson -> 'a t Conv.of_yojson
+  val to_yojson : 'a Conv.to_yojson -> 'a t Conv.to_yojson
+end
+
+type 'a t = { libraries : 'a Library.t list }
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+val of_yojson : 'a Conv.of_yojson -> 'a t Conv.of_yojson
+val to_yojson : 'a Conv.to_yojson -> 'a t Conv.to_yojson

--- a/src/voodoo/serialize/status.ml
+++ b/src/voodoo/serialize/status.ml
@@ -1,0 +1,69 @@
+module Otherdocs = struct
+  type t = {
+    readme : Fpath.t list;
+    license : Fpath.t list;
+    changes : Fpath.t list;
+    others : Fpath.t list;
+  }
+
+  let empty = { readme = []; license = []; changes = []; others = [] }
+
+  let equal x y =
+    Util.list_equal Fpath.equal x.readme y.readme
+    && Util.list_equal Fpath.equal x.license y.license
+    && Util.list_equal Fpath.equal x.changes y.changes
+    && Util.list_equal Fpath.equal x.others y.others
+
+  let pp fs x =
+    Format.fprintf fs "(readme:%a) (license:%a) (changes:%a) (others:%a)"
+      (Format.pp_print_list Fpath.pp)
+      x.readme
+      (Format.pp_print_list Fpath.pp)
+      x.license
+      (Format.pp_print_list Fpath.pp)
+      x.changes
+      (Format.pp_print_list Fpath.pp)
+      x.others
+
+  let of_yojson json =
+    let open Yojson.Safe.Util in
+    let readme =
+      json |> member "readme" |> to_list |> List.map Fpath_.of_yojson
+    in
+    let license =
+      json |> member "license" |> to_list |> List.map Fpath_.of_yojson
+    in
+    let changes =
+      json |> member "changes" |> to_list |> List.map Fpath_.of_yojson
+    in
+    let others =
+      json |> member "others" |> to_list |> List.map Fpath_.of_yojson
+    in
+    { readme; license; changes; others }
+
+  let to_yojson { readme; license; changes; others } =
+    let readme = ("readme", `List (List.map Fpath_.to_yojson readme)) in
+    let license = ("license", `List (List.map Fpath_.to_yojson license)) in
+    let changes = ("changes", `List (List.map Fpath_.to_yojson changes)) in
+    let others = ("others", `List (List.map Fpath_.to_yojson others)) in
+    `Assoc [ readme; license; changes; others ]
+end
+
+type t = { failed : bool; otherdocs : Otherdocs.t }
+
+let equal x y = x.failed = y.failed && Otherdocs.equal x.otherdocs y.otherdocs
+
+let pp fs x =
+  Format.fprintf fs "(failed:%b) (otherdocs:%a)" x.failed Otherdocs.pp
+    x.otherdocs
+
+let of_yojson json =
+  let open Yojson.Safe.Util in
+  let failed = json |> member "failed" |> to_bool in
+  let otherdocs = json |> member "otherdocs" |> Otherdocs.of_yojson in
+  { failed; otherdocs }
+
+let to_yojson { failed; otherdocs } =
+  let failed = ("failed", `Bool failed) in
+  let otherdocs = ("otherdocs", Otherdocs.to_yojson otherdocs) in
+  `Assoc [ failed; otherdocs ]

--- a/src/voodoo/serialize/status.mli
+++ b/src/voodoo/serialize/status.mli
@@ -1,0 +1,21 @@
+module Otherdocs : sig
+  type t = {
+    readme : Fpath.t list;
+    license : Fpath.t list;
+    changes : Fpath.t list;
+    others : Fpath.t list;
+  }
+
+  val empty : t
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val of_yojson : t Conv.of_yojson
+  val to_yojson : t Conv.to_yojson
+end
+
+type t = { failed : bool; otherdocs : Otherdocs.t }
+
+val equal : t -> t -> bool
+val pp : Format.formatter -> t -> unit
+val of_yojson : t Conv.of_yojson
+val to_yojson : t Conv.to_yojson

--- a/src/voodoo/serialize/string_.ml
+++ b/src/voodoo/serialize/string_.ml
@@ -1,0 +1,4 @@
+type t = string
+
+let of_yojson json = json |> Yojson.Safe.Util.to_string
+let to_yojson x = `String x

--- a/src/voodoo/serialize/string_.mli
+++ b/src/voodoo/serialize/string_.mli
@@ -1,0 +1,4 @@
+type t = string
+
+val of_yojson : t Conv.of_yojson
+val to_yojson : t Conv.to_yojson

--- a/src/voodoo/serialize/util.ml
+++ b/src/voodoo/serialize/util.ml
@@ -1,0 +1,5 @@
+let rec list_equal f x y =
+  match (x, y) with
+  | [], [] -> true
+  | [], _ | _, [] -> false
+  | a :: b, c :: d -> f a c && list_equal f b d

--- a/src/voodoo/serialize/util.mli
+++ b/src/voodoo/serialize/util.mli
@@ -1,0 +1,1 @@
+val list_equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool

--- a/src/voodoo/util.mli
+++ b/src/voodoo/util.mli
@@ -2,4 +2,4 @@ val is_hidden : string -> bool
 val lines_of_channel : in_channel -> string list
 val lines_of_process : Bos.Cmd.t -> string list
 val mkdir_p : Fpath.t -> unit
-val copy : Fpath.t -> Fpath.t -> (unit, [> Rresult.R.msg ]) result
+val copy : Fpath.t -> Fpath.t -> (unit, [> Bos_setup.R.msg ]) Bos_setup.result

--- a/test/unit/serialize/dune
+++ b/test/unit/serialize/dune
@@ -1,0 +1,4 @@
+(test
+ (name main)
+ (package voodoo-lib)
+ (libraries alcotest voodoo-lib.serialize))

--- a/test/unit/serialize/main.ml
+++ b/test/unit/serialize/main.ml
@@ -1,0 +1,12 @@
+let () =
+  Alcotest.run "voodoo-serialize"
+    [
+      Test_string.suite;
+      Test_fpath.suite;
+      Test_package_info.Kind.suite;
+      Test_package_info.Module.suite;
+      Test_package_info.Library.suite;
+      Test_package_info.suite;
+      Test_status.Otherdocs.suite;
+      Test_status.suite;
+    ]

--- a/test/unit/serialize/test_fpath.ml
+++ b/test/unit/serialize/test_fpath.ml
@@ -1,0 +1,15 @@
+open Voodoo_serialize.Fpath_
+
+let path = Alcotest.testable Fpath.pp Fpath.equal
+
+let test str =
+  let test_name = Format.sprintf "%S" str in
+  ( str,
+    `Quick,
+    fun () ->
+      let expected = Fpath.v str in
+      let got = of_yojson @@ to_yojson @@ Fpath.v str in
+      Alcotest.(check path) test_name got expected )
+
+let inputs = [ "/"; "xx"; "`"; "   "; "  "; "\""; "//" ]
+let suite = ("Fpath", List.map test inputs)

--- a/test/unit/serialize/test_package_info.ml
+++ b/test/unit/serialize/test_package_info.ml
@@ -1,0 +1,96 @@
+open Voodoo_serialize.Package_info
+
+module Kind = struct
+  include Kind
+
+  let kind = Alcotest.testable pp equal
+
+  let test k =
+    let test_name = Format.asprintf "%a" pp k in
+    ( test_name,
+      `Quick,
+      fun () ->
+        let expected = k in
+        let got = of_yojson @@ to_yojson @@ k in
+        Alcotest.(check kind) test_name got expected )
+
+  let inputs =
+    [
+      `Module;
+      `Page;
+      `LeafPage;
+      `ModuleType;
+      `Parameter 1;
+      `Class;
+      `ClassType;
+      `File;
+    ]
+
+  let suite = ("Package_info.Kind", List.map test inputs)
+end
+
+module Module = struct
+  include Module
+
+  let module_ = Alcotest.testable pp equal
+
+  let test k =
+    let test_name = Format.asprintf "%a" pp k in
+    ( test_name,
+      `Quick,
+      fun () ->
+        let expected = k in
+        let got = of_yojson @@ to_yojson @@ k in
+        Alcotest.(check module_) test_name got expected )
+
+  let inputs =
+    [
+      { name = ""; submodules = []; kind = `Module };
+      {
+        name = "foo";
+        submodules = [ { name = "bar"; submodules = []; kind = `Class } ];
+        kind = `Page;
+      };
+    ]
+
+  let suite = ("Package_info.Module", List.map test inputs)
+end
+
+module Library = struct
+  include Library
+
+  let library = Alcotest.testable (pp Module.pp) (equal Module.equal)
+
+  let test k =
+    let test_name = Format.asprintf "%a" (pp Module.pp) k in
+    ( test_name,
+      `Quick,
+      fun () ->
+        let expected = k in
+        let got =
+          of_yojson Module.of_yojson @@ to_yojson Module.to_yojson @@ k
+        in
+        Alcotest.(check library) test_name got expected )
+
+  let inputs =
+    [
+      { name = ""; modules = []; dependencies = [] };
+      { name = "foo"; modules = Module.inputs; dependencies = [ "bar" ] };
+    ]
+
+  let suite = ("Package_info.Library", List.map test inputs)
+end
+
+let package_info = Alcotest.testable (pp Module.pp) (equal Module.equal)
+
+let test x =
+  let test_name = Format.asprintf "%a" (pp Module.pp) x in
+  ( test_name,
+    `Quick,
+    fun () ->
+      let expected = x in
+      let got = of_yojson Module.of_yojson @@ to_yojson Module.to_yojson @@ x in
+      Alcotest.(check package_info) test_name got expected )
+
+let inputs = [ { libraries = [] }; { libraries = Library.inputs } ]
+let suite = ("Package_info", List.map test inputs)

--- a/test/unit/serialize/test_status.ml
+++ b/test/unit/serialize/test_status.ml
@@ -1,0 +1,46 @@
+open Voodoo_serialize.Status
+
+module Otherdocs = struct
+  include Otherdocs
+
+  let otherdocs = Alcotest.testable pp equal
+
+  let test k =
+    let test_name = Format.asprintf "%a" pp k in
+    ( test_name,
+      `Quick,
+      fun () ->
+        let expected = k in
+        let got = of_yojson @@ to_yojson @@ k in
+        Alcotest.(check otherdocs) test_name got expected )
+
+  let dummy =
+    {
+      readme = [ Fpath.v "/a" ];
+      license = [ Fpath.v "/b" ];
+      changes = [ Fpath.v "/c" ];
+      others = [ Fpath.v "/d" ];
+    }
+
+  let inputs = [ empty; dummy ]
+  let suite = ("Status.Otherdocs", List.map test inputs)
+end
+
+let status = Alcotest.testable pp equal
+
+let test x =
+  let test_name = Format.asprintf "%a" pp x in
+  ( test_name,
+    `Quick,
+    fun () ->
+      let expected = x in
+      let got = of_yojson @@ to_yojson @@ x in
+      Alcotest.(check status) test_name got expected )
+
+let inputs =
+  [
+    { failed = true; otherdocs = Otherdocs.empty };
+    { failed = false; otherdocs = Otherdocs.dummy };
+  ]
+
+let suite = ("Status", List.map test inputs)

--- a/test/unit/serialize/test_string.ml
+++ b/test/unit/serialize/test_string.ml
@@ -1,0 +1,13 @@
+open Voodoo_serialize.String_
+
+let test str =
+  let test_name = Format.sprintf "%S" str in
+  ( str,
+    `Quick,
+    fun () ->
+      let expected = str in
+      let got = of_yojson @@ to_yojson str in
+      Alcotest.(check string) test_name got expected )
+
+let inputs = [ ""; "xx"; "`"; "   "; "  "; "\"" ]
+let suite = ("String", List.map test inputs)

--- a/voodoo-do.opam
+++ b/voodoo-do.opam
@@ -15,7 +15,7 @@ depends: [
   "bos"
   "astring"
   "cmdliner"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/voodoo-gen.opam
+++ b/voodoo-gen.opam
@@ -16,9 +16,8 @@ depends: [
   "conf-pandoc"
   "astring"
   "cmdliner"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "bos"
-  "ppx_deriving_yojson" {>= "3.6.0"}
   "sexplib"
   "fpath"
   "conf-jq" {with-test}

--- a/voodoo-lib.opam
+++ b/voodoo-lib.opam
@@ -10,12 +10,12 @@ homepage: "https://github.com/ocaml-doc/voodoo"
 bug-reports: "https://github.com/ocaml-doc/voodoo/issues"
 depends: [
   "dune" {>= "3.0"}
+  "alcotest" {with-test & >= "0.7.0"}
   "bos"
   "astring"
   "fpath"
-  "ppx_deriving_yojson" {>= "3.6.0"}
   "sexplib"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/voodoo-prep.opam
+++ b/voodoo-prep.opam
@@ -13,7 +13,7 @@ depends: [
   "cmdliner"
   "fpath"
   "bos"
-  "opam-format"
+  "opam-format" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
- drop the `ppx_deriving_yojson` dependency (that adds a lower bound on ocaml)
- have the `of_yojson`/`to_yojson` in one place
- have the lib as a package so it can be used in `ocamlorg_package`
- have some unit tests