### PR TITLE
Don't convert .org to markdown twice - do it only in voodoo-gen

### DIFF
--- a/src/voodoo/otherdocs.ml
+++ b/src/voodoo/otherdocs.ml
@@ -1,19 +1,5 @@
 (* otherdocs *)
 
-let convert_org_to_md src =
-  let dst = Filename.remove_extension src ^ ".md" in
-  let cmd =
-    Bos.Cmd.(
-      v "pandoc" % "--wrap" % "none" % "--from" % "org" % "--to" % "markdown"
-      % "-o" % dst % src)
-  in
-  let () =
-    match Bos.OS.Cmd.run cmd with
-    | Ok () -> ()
-    | Error (`Msg err) -> failwith err
-  in
-  dst
-
 (* Copy the other docs into the version directory *)
 let copy version docs opam_file =
   let dir = Fpath.(Mld.link_dir version / version.name) in
@@ -28,20 +14,7 @@ let copy version docs opam_file =
     in
     let dst = Fpath.(dir // n) in
     Format.eprintf "dst: %a\n%!" Fpath.pp dst;
-    match Fpath.get_ext src with
-    | ".org" -> (
-        let src_md =
-          match Fpath.of_string (convert_org_to_md (Fpath.to_string src)) with
-          | Ok s -> s
-          | Error (`Msg err) -> failwith err
-        in
-        let dst_md = Fpath.set_ext ".md" dst in
-        match (Util.copy src dst, Util.copy src_md dst_md) with
-        | Ok _, Ok _ -> [ dst; dst_md ]
-        | Ok _, Error _ -> [ dst ]
-        | Error _, Ok _ -> [ dst; dst_md ]
-        | Error _, Error _ -> [])
-    | _ -> ( match Util.copy src dst with Ok _ -> [ dst ] | Error _ -> [])
+    match Util.copy src dst with Ok _ -> [ dst ] | Error _ -> []
   in
   let opam_file =
     match opam_file with

--- a/test/can-render-org-files.t
+++ b/test/can-render-org-files.t
@@ -20,8 +20,7 @@ Generates a status.json file
     "failed": false,
     "otherdocs": {
       "readme": [
-        "linked/p/base/v0.15.1/doc/README.org",
-        "linked/p/base/v0.15.1/doc/README.md"
+        "linked/p/base/v0.15.1/doc/README.org"
       ],
       "license": [
         "linked/p/base/v0.15.1/doc/LICENSE.md"
@@ -39,7 +38,6 @@ Converted the README.org file in markdown
   $ ls output/p/base/v0.15.1/
   CHANGES.md.html.json
   LICENSE.md.html.json
-  README.md.html.json
   README.org.html.json
   doc
   index.js


### PR DESCRIPTION
`voodoo-do` was calling `pandoc` which causes some docs builds to fail.

In this patch, I remove the conversion of `.org` files to `.md` files from `voodoo-do`. This way, `voodoo-do` doesn't need `pandoc`, only `voodoo-gen` does.

Now, `voodoo-do` only copies the other doc files (.org, .md) and rendering of them is done in `voodoo-gen`.