### PR TITLE
voodoo-do: Simplify voodoo-do cli, make `-p` required

### DIFF
--- a/src/voodoo-do/do.ml
+++ b/src/voodoo-do/do.ml
@@ -272,27 +272,3 @@ let run pkg_name is_blessed failed =
   if failed then
     Bos.OS.File.write Fpath.(output_path / "failed") "failed" |> Result.get_ok;
   ()
-
-let run_all () =
-  Format.eprintf
-    "Handling all packages. Getting dependency data from current opam switch\n\
-     %!";
-  let packages = Opam.all_opam_packages () in
-  Format.eprintf "Metadata found";
-  let deps = List.map (fun pkg -> (pkg, Opam.dependencies pkg)) packages in
-  let done_pkgs : Opam.package list ref = ref [] in
-  let rec doit pkg =
-    if List.mem pkg !done_pkgs then ()
-    else
-      let deps_opt = try Some (List.assoc pkg deps) with _ -> None in
-      match deps_opt with
-      | Some deps ->
-          List.iter doit deps;
-          Format.eprintf "Building docs for package %s\n%!" pkg.Opam.name;
-          (try run pkg.Opam.name true false
-           with e ->
-             Format.eprintf "Ignoring failure %s!\n%!" (Printexc.to_string e));
-          done_pkgs := pkg :: !done_pkgs
-      | None -> ()
-  in
-  List.iter doit packages

--- a/src/voodoo-do/do.mli
+++ b/src/voodoo-do/do.mli
@@ -1,2 +1,1 @@
 val run : string -> bool -> bool -> unit
-val run_all : unit -> unit

--- a/src/voodoo-do/main.ml
+++ b/src/voodoo-do/main.ml
@@ -6,12 +6,12 @@ open Cmdliner
 
 let run package blessed switch failed =
   Opam.switch := switch;
-  match package with None -> Do.run_all () | Some p -> Do.run p blessed failed
+  Do.run package blessed failed
 
 let package =
   let doc = "Select the package to process" in
   Arg.(
-    value & opt (some string) None & info [ "p"; "package" ] ~docv:"PKG" ~doc)
+    required & opt (some string) None & info [ "p"; "package" ] ~docv:"PKG" ~doc)
 
 let blessed =
   let doc = "Mark the package as blessed" in
@@ -23,7 +23,7 @@ let switch =
     value & opt (some string) None & info [ "s"; "switch" ] ~doc ~docv:"SWITCH")
 
 let failed =
-  let doc = "Indicate that the build was a failed" in
+  let doc = "Indicate that the build failed" in
   Arg.(value & flag & info [ "failed" ] ~doc)
 
 let cmd =

--- a/src/voodoo/opam.mli
+++ b/src/voodoo/opam.mli
@@ -1,6 +1,2 @@
-type package = { name : string; version : string }
-
 val switch : string option ref
-val dependencies : package -> package list
-val all_opam_packages : unit -> package list
 val find : Package.t -> (Fpath.t, [> Bos_setup.R.msg ]) Bos_setup.result


### PR DESCRIPTION
Option `-p` is always used so let's make it required and remove the `run_all` function, that allows us to drop a lot of opam stuff
