### PR TITLE
Change Soft_break to emit space character in markdown renderer

### DIFF
--- a/src/voodoo-gen/markdown.ml
+++ b/src/voodoo-gen/markdown.ml
@@ -15,7 +15,7 @@ let rec inline : 'attr inline -> Odoc_document.Types.Inline.t = function
   | Code (_, c) ->
       [ { desc = Source [ Elt [ { desc = Text c; attr = [] } ] ]; attr = [] } ]
   | Hard_break _ -> [ { desc = Linebreak; attr = [] } ]
-  | Soft_break _ -> [ { desc = Text " "; attr = []} ]
+  | Soft_break _ -> [ { desc = Text " "; attr = [] } ]
   | Link (_, l) ->
       [ { desc = Link (l.destination, inline l.label); attr = [] } ]
   | Image _ -> []

--- a/src/voodoo-gen/markdown.ml
+++ b/src/voodoo-gen/markdown.ml
@@ -15,7 +15,7 @@ let rec inline : 'attr inline -> Odoc_document.Types.Inline.t = function
   | Code (_, c) ->
       [ { desc = Source [ Elt [ { desc = Text c; attr = [] } ] ]; attr = [] } ]
   | Hard_break _ -> [ { desc = Linebreak; attr = [] } ]
-  | Soft_break _ -> [ { desc = Linebreak; attr = [] } ]
+  | Soft_break _ -> [ { desc = Text " "; attr = []} ]
   | Link (_, l) ->
       [ { desc = Link (l.destination, inline l.label); attr = [] } ]
   | Image _ -> []


### PR DESCRIPTION
`Soft_break` in markdown rendering (see README/LICENSE/CHANGELOG files) was turned into a `Linebreak` in the generated odoc document.

This resulted in unwanted line breaks in the emitted HTML documents.

This patch changes rendering to instead emit a space character.