### PR TITLE
Fix unwrapped dune libraries

### DIFF
--- a/src/voodoo/dune.ml
+++ b/src/voodoo/dune.ml
@@ -71,8 +71,8 @@ let process_unwrapped_library l =
   let modules =
     List.fold_right
       (fun l acc ->
-        let r = l >>= assoc "name" >>= string_of_atom in
-        match r with Ok x -> x :: acc | Error _ -> acc)
+        let r = l >>= assoc "obj_name" >>= string_of_atom in
+        match r with Ok x -> (String.capitalize_ascii x) :: acc | Error _ -> acc)
       modules []
   in
   Ok (Library.Unwrapped { modules })


### PR DESCRIPTION
Untested beyond the 'do' phase, but before this produced:

```
{0 camlp-streams 5.0.1}
{1 Libraries}
This package provides the following libraries (via dune):
{2 camlp-streams}
Documentation: {!modules:}
```

and after it produces:

```
{0 camlp-streams 5.0.1}
{1 Libraries}
This package provides the following libraries (via dune):
{2 camlp-streams}
Documentation: {!modules:Genlex Stream}
```